### PR TITLE
MATH_SVG["latex"] does not seem to get read from config

### DIFF
--- a/pelican/plugins/math_svg/settings.py
+++ b/pelican/plugins/math_svg/settings.py
@@ -95,6 +95,13 @@ class PelicanMathSettings:
         obj.scale_inline = settings.get("scale_inline", obj.scale_inline)
         obj.scale_display = settings.get("scale_display", obj.scale_display)
 
+        latex = settings.get("latex", None)
+        if latex is not None:
+            obj.latex_args = latex.get("args", obj.latex_args)
+            obj.latex_preamble = latex.get("preamble", obj.latex_preamble)
+            obj.latex_preamble.extend(latex.get("preamble_extend", ()))
+            obj.latex_program = latex.get("program", obj.latex_program)
+
         obj.strokeonly_class = settings.get("strokeonly_class", obj.strokeonly_class)
 
         if "scour" in settings:


### PR DESCRIPTION
While trying to change lualatex to pdflatex I noticed that changing MATH_SVG["latex"] did not seem to do anything. My best guess is, the data should be read from here but they are not? There is also no other location I could find which reads MATH_SVG["latex"]. I hope this fixes it.